### PR TITLE
init variables

### DIFF
--- a/src/utils/arrangeIntoTree.js
+++ b/src/utils/arrangeIntoTree.js
@@ -20,13 +20,13 @@ function arrangeIntoTree(paths) {
 		}
 
 		const path = node.link.split('/').filter(elem => elem);
-		let currentLevel = tree;
+        let currentLevel = tree || [];
 		for (let j = 0; j < path.length; j++) {
 			let part = path[j];
-			let existingPath = findWhere(currentLevel, 'id', part);
+            let existingPath = findWhere(currentLevel || [], 'id', part);
 
 			if (existingPath) {
-				currentLevel = existingPath.items;
+                currentLevel = existingPath.items || [];
 			} else if (node.id === part || node.id === 'index') {
 				// if (findWhere(currentLevel, 'id', part)) // se já existir na árvore eu dou continue.
 				currentLevel.push(node);


### PR DESCRIPTION
Hey @diegonvs,

When we add new indexes, sometimes we get the error:

```
error Building static HTML for pages failed

See our docs page on debugging HTML builds for help https://goo.gl/yL9lND

  1 | function findWhere(array, key, value) {
  2 | 	let t = 0;
> 3 | 	while (t < array.length && array[t][key] !== value) { t++; };
    | 	                 ^
  4 |
  5 | 	if (t < array.length) {
  6 | 		return array[t]


  WebpackError: TypeError: Cannot read property 'length' of undefined

  - arrangeIntoTree.js:3 findWhere
    lib/src/utils/arrangeIntoTree.js:3:19

  - arrangeIntoTree.js:26 _loop
    lib/src/utils/arrangeIntoTree.js:26:23

  - arrangeIntoTree.js:24 arrangeIntoTree
    lib/src/utils/arrangeIntoTree.js:24:41

  - Sidebar.js:34 getSection
    lib/src/components/Sidebar/Sidebar.js:34:25

  - Sidebar.js:117 render
    lib/src/components/Sidebar/Sidebar.js:117:34

  - gatsby-browser-entry.js:23 Object.children
    lib/.cache/gatsby-browser-entry.js:23:11


  - bootstrap:24 a.read
    lib/webpack/bootstrap:24:1

  - bootstrap:36 renderToString
    lib/webpack/bootstrap:36:1

  - static-entry.js:190 Module../.cache/static-entry.js.__webpack_exports__.default
    lib/.cache/static-entry.js:190:18

  - bootstrap:24 Promise
    lib/webpack/bootstrap:24:1


  - gatsby-browser-entry.js:1 Promise._resolveFromExecutor
    lib/.cache/gatsby-browser-entry.js:1:1

  - bootstrap:68 new Promise
    lib/webpack/bootstrap:68:1


  - bootstrap:5 tryCatcher
    lib/webpack/bootstrap:5:1
```

We think this pull fix this issue.

Thanks!