### PR TITLE
Fix documentation index

### DIFF
--- a/src/utils/arrangeIntoTree.js
+++ b/src/utils/arrangeIntoTree.js
@@ -30,7 +30,7 @@ function arrangeIntoTree(paths) {
 			} else if (node.id === part || node.id === 'index') {
 				currentLevel.push(node);
 			} else {
-				let nodePart = paths.find(elem => elem.link.endsWith(`${part}/index`));
+				let nodePart = paths.find(elem => elem.link.endsWith(`/${part}/index`));
 				let newPart = {
 					id: part,
 					items: [],

--- a/src/utils/arrangeIntoTree.js
+++ b/src/utils/arrangeIntoTree.js
@@ -23,12 +23,18 @@ function arrangeIntoTree(paths) {
         let currentLevel = tree || [];
 		for (let j = 0; j < path.length; j++) {
 			let part = path[j];
-            let existingPath = findWhere(currentLevel || [], 'id', part);
 
-			if (existingPath) {
-                currentLevel = existingPath.items || [];
-			} else if (node.id === part || node.id === 'index') {
+			// Last part of the path, just add it to the current level
+			if (j === path.length - 1) {
 				currentLevel.push(node);
+				break;
+			}
+
+			let existingPath = findWhere(currentLevel || [], 'id', part);
+
+			// If the path exist, navigate, if not, create it and navigate
+			if (existingPath) {
+				currentLevel = existingPath.items || [];
 			} else {
 				let nodePart = paths.find(elem => elem.link.endsWith(`/${part}/index`));
 				let newPart = {


### PR DESCRIPTION
Hey!

We've noticed that in some scenarios the current implementation of `arrangeIntoTree` had strange behavior. 

The scenarios mentioned were having a path like this `/docs/user-account/user-account.md`
or having two path ending in the same way like `/docs/user-account/user-account.md` and `/docs/user-account/my-user-account.md``

You can reproduce this behaviour [here](https://github.com/liferay/headlessapis.wedeploy.io/commit/2b105116b2206a1219181813e008a3322ad549cf)

I hope this helps, if you have any question or comment, don't hesitate and ask :D