### PR TITLE
Direct edit links

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,7 @@
 ALGOLIA_API_KEY=
 ALGOLIA_INDEX_NAME=
 GA_TRACKING_ID=UA-129292646-1
+ISSUES_URL=https://github.com/diegonvs/gatsby-boilerplate/issues
 GITHUB_REPO=https://github.com/diegonvs/gatsby-boilerplate
 PROJECT_NAME=Gatsby Boilerplate
 WEDEPLOY_AUTH_SERVICE_URL=auth-boilerplate.wedeploy.io

--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,7 @@
 ALGOLIA_API_KEY=
 ALGOLIA_INDEX_NAME=
 GA_TRACKING_ID=UA-129292646-1
+EDIT_CONTENT_URL=https://github.com/diegonvs/gatsby-boilerplate/edit/master/content
 ISSUES_URL=https://github.com/diegonvs/gatsby-boilerplate/issues
 GITHUB_REPO=https://github.com/diegonvs/gatsby-boilerplate
 PROJECT_NAME=Gatsby Boilerplate

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,7 @@
 ALGOLIA_API_KEY=
 ALGOLIA_INDEX_NAME=
 GA_TRACKING_ID=UA-129292646-1
+ISSUES_URL=https://github.com/diegonvs/gatsby-boilerplate/issues
 GITHUB_REPO=https://github.com/diegonvs/gatsby-boilerplate
 PROJECT_NAME=Gatsby Boilerplate
 WEDEPLOY_AUTH_SERVICE_URL=auth-boilerplate.wedeploy.io

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,7 @@
 ALGOLIA_API_KEY=
 ALGOLIA_INDEX_NAME=
 GA_TRACKING_ID=UA-129292646-1
+EDIT_CONTENT_URL=https://github.com/diegonvs/gatsby-boilerplate/edit/master/content
 ISSUES_URL=https://github.com/diegonvs/gatsby-boilerplate/issues
 GITHUB_REPO=https://github.com/diegonvs/gatsby-boilerplate
 PROJECT_NAME=Gatsby Boilerplate

--- a/src/components/SimpleFooter/SimpleFooter.js
+++ b/src/components/SimpleFooter/SimpleFooter.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const SimpleFooter = (props) => {
 
-    const {githubRepo} = props;
+    const {githubRepo, issuesURL} = props;
 
     return (
         <footer className="clay-site-container container-fluid">
@@ -13,7 +13,7 @@ const SimpleFooter = (props) => {
                 <div className="col-6 p-md-0">
                     <ul className="social-icons">
                         <li className="mr-2">
-                            <a className="rounded-circle sticker sticker-secondary" href={`${githubRepo}/issues`}  target="_blank" rel="noopener noreferrer">
+                            <a className="rounded-circle sticker sticker-secondary" href={issuesURL} target="_blank" rel="noopener noreferrer">
                                 <svg aria-hidden="true" className="lexicon-icon lexicon-icon-bars">
                                     <use xlinkHref="/images/icons/icons.svg#comments" />
                                 </svg>

--- a/src/components/SimpleFooter/SimpleFooter.js
+++ b/src/components/SimpleFooter/SimpleFooter.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const SimpleFooter = (props) => {
 
-    const {githubRepo, issuesURL} = props;
+    const {editContentURL, issuesURL, slug} = props;
 
     return (
         <footer className="clay-site-container container-fluid">
@@ -20,7 +20,7 @@ const SimpleFooter = (props) => {
                             </a>
                         </li>
                         <li>
-                            <a className="rounded-circle sticker sticker-secondary" href={`${githubRepo}`}  target="_blank" rel="noopener noreferrer">
+                            <a className="rounded-circle sticker sticker-secondary" href={`${editContentURL}/${slug.replace("html", "md")}`} target="_blank" rel="noopener noreferrer">
                                 <img className="lexicon-icon" src="/images/home/GitHub-Mark-64px.svg" alt="" />
                             </a>
                         </li>

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -83,7 +83,7 @@ export default class Docs extends Component {
                                 </div>
                             </div>
 
-                            <SimpleFooter githubRepo={process.env.GITHUB_REPO} />
+                            <SimpleFooter githubRepo={process.env.GITHUB_REPO} issuesURL={process.env.ISSUES_URL} />
                         </div>
                     </main>
                 </div>

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -83,7 +83,7 @@ export default class Docs extends Component {
                                 </div>
                             </div>
 
-                            <SimpleFooter githubRepo={process.env.GITHUB_REPO} issuesURL={process.env.ISSUES_URL} />
+                            <SimpleFooter editContentURL={process.env.EDIT_CONTENT_URL} issuesURL={process.env.ISSUES_URL} slug={this.props["*"]}/>
                         </div>
                     </main>
                 </div>


### PR DESCRIPTION
Current implementation expects that the documentation and the library repositories are the same one.

This PR enables three different things:

- Having Github buttons in main page and navigation menu to point to library's repository.
- Having "issues" button in docs' footer point to documentation repository's issues page.
- Having "github" button in doc's fotter point to directly edit that documentation page in Github.

![](https://media.giphy.com/media/8ey1nnwx0VWqmbVWyv/giphy.gif)