### PR TITLE
Move from WeDeploy Auth to Netlify Identity

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,5 +5,4 @@ EDIT_CONTENT_URL=https://github.com/diegonvs/gatsby-boilerplate/edit/master/cont
 ISSUES_URL=https://github.com/diegonvs/gatsby-boilerplate/issues
 GITHUB_REPO=https://github.com/diegonvs/gatsby-boilerplate
 PROJECT_NAME=Gatsby Boilerplate
-WEDEPLOY_AUTH_SERVICE_URL=auth-boilerplate.wedeploy.io
-WEDEPLOY_MASTER_TOKEN=0bbea119-1d30-43ed-800b-1487ef52b316
+NETLIFY_IDENTITY_API_URL=

--- a/.env.production
+++ b/.env.production
@@ -5,5 +5,4 @@ EDIT_CONTENT_URL=https://github.com/diegonvs/gatsby-boilerplate/edit/master/cont
 ISSUES_URL=https://github.com/diegonvs/gatsby-boilerplate/issues
 GITHUB_REPO=https://github.com/diegonvs/gatsby-boilerplate
 PROJECT_NAME=Gatsby Boilerplate
-WEDEPLOY_AUTH_SERVICE_URL=auth-boilerplate.wedeploy.io
-WEDEPLOY_MASTER_TOKEN=0bbea119-1d30-43ed-800b-1487ef52b316
+NETLIFY_IDENTITY_API_URL=

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,20 @@
+const netlifyIdentity = require('netlify-identity-widget');
+const netlifyApiUrl = process.env.NETLIFY_IDENTITY_API_URL;
 require('./src/styles/main.scss');
 
 // A stub function is needed because gatsby won't load this file otherwise
 // (https://github.com/gatsbyjs/gatsby/issues/6759)
 exports.onClientEntry = () => {};
+
+exports.onInitialClientRender = () => {
+    if (netlifyApiUrl !== "") {
+        netlifyIdentity.init({
+            // Absolute url to endpoint.  ONLY USE IN SPECIAL CASES!
+            // See https://github.com/netlify/netlify-identity-widget/#netlifyidentityinitopts
+            APIUrl: netlifyApiUrl
+        });
+    } else {
+        netlifyIdentity.init();
+    }
+    window.netlifyIdentity = netlifyIdentity
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "languages": "0.1.3",
     "metal-clipboard": "2.0.1",
     "metal-tabs": "2.3.1",
+    "netlify-identity-widget": "^1.5.2",
     "node-sass": "4.11.0",
     "nothing": "0.1.0",
     "prismjs": "1.15.0",

--- a/src/components/Auth/Auth.js
+++ b/src/components/Auth/Auth.js
@@ -1,32 +1,16 @@
 import React, { Component } from 'react';
-import { isLoggedIn } from '../../services/auth';
-import Login from '../Login';
+import { navigate } from 'gatsby';
+import {handleLogin, isBrowser, isLoggedIn} from '../../services/auth';
 
 class Auth extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            login: false,
-        }
-    }
-
-    changeLoginState(isLogged) {
-        this.setState(() => ({
-            login: isLogged
-        }));
-    }
-
-    componentDidMount() {
-        this.setState({
-            login: !!isLoggedIn()
-        })
-    }
-
     render() {
-        if (this.props.needsAuth && !this.state.login) {
-            return (
-                <Login changeLoginState={this.changeLoginState.bind(this)} />
-            );
+        if (this.props.needsAuth && !isLoggedIn()) {
+            handleLogin().then(() => {
+                if(isBrowser()) {
+                    navigate(window.location.pathname);
+                }
+            });
+            return null;
         }
 
         return this.props.children;

--- a/src/components/LayoutNav/LayoutNav.js
+++ b/src/components/LayoutNav/LayoutNav.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Link, withPrefix } from 'gatsby';
 import classnames from 'classnames';
 
-import { isLoggedIn, logout } from '../../services/auth';
+import Login from '../Login';
 
 class LayoutNav extends Component {
     constructor() {
@@ -27,17 +27,6 @@ class LayoutNav extends Component {
         } else {
             this.refs.navElement.classList.remove('scroll');
         }
-    }
-
-    _handleLogout() {
-        logout()
-            .then(() => {
-                this.forceUpdate();
-            })
-            .catch((error) => {
-                alert(error);
-                window.location.reload();
-            });
     }
 
     componentDidMount() {
@@ -94,11 +83,9 @@ class LayoutNav extends Component {
                         <li className="nav-item">
                             <Link className="nav-link ml-lg-3" to="/updates/">Updates</Link>
                         </li>
-                        {isLoggedIn() ? (
-                            <li className="nav-item">
-                                <Link className="nav-link ml-lg-3" to="#" onClick={this._handleLogout.bind(this)}>Logout</Link>
-                            </li>
-                        ) : ''}
+                        <li className="nav-item">
+                            <Login />
+                        </li>
                         <li className="nav-item">
                             <a className="mx-3 mr-lg-0" href={process.env.GITHUB_REPO}  target="_blank" rel="noopener noreferrer">
                                 <img src={withPrefix("/images/home/GitHub-Mark-64px.svg")} alt="" />

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -1,78 +1,58 @@
-import React, {Component} from 'react';
-import { handleLogin, handleSignUp} from '../../services/auth'
+import React, { Component } from 'react';
+import { handleLogin, handleSignUp, logout, isLoggedIn, isBrowser } from '../../services/auth'
+import { navigate } from 'gatsby';
 
 class Login extends Component {
-    state = {
-        email: '',
-        password: ''
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            login: isLoggedIn()
+        }
+        this._handleLogin = this._handleLogin.bind(this);
+        this._handleLogout = this._handleLogout.bind(this);
     }
 
-    handleUpdate = (event) => {
-        this.setState({
-            [event.target.name]: event.target.value,
-        })
-    }
-
-    _handleSignUp = (event) => {
+    _handleLogin = (event) => {
         event.preventDefault();
-
-        handleSignUp(this.state).then(() => {
-            this.props.changeLoginState(true);
-        }).catch(() => {
-            this.props.changeLoginState(false);
+        handleLogin().then(() => {
+            this.setState({
+                login: isLoggedIn()
+            });
         });
     }
 
-    _handleSubmit = (event) => {
+    _handleLogout = (event) => {
         event.preventDefault();
-
-        handleLogin(this.state).then(() => {
-            this.props.changeLoginState(true);
-        }).catch(() => {
-            this.props.changeLoginState(false);
+        logout().then(() => {
+            this.setState({
+                login: isLoggedIn()
+            });
+            if(isBrowser()) {
+                navigate('/');
+            }
         });
     }
 
     render() {
+        let button;
+        if(this.state.login) {
+            button =
+                <button className="btn btn-sm btn-outline-light font-weight-bold mx-3"
+                        onClick={this._handleLogout}>
+                    Logout
+                </button>;
+        } else {
+            button =
+                <button className="btn btn-sm btn-outline-light font-weight-bold mx-3"
+                        onClick={this._handleLogin}>
+                    Sign Up / Login
+                </button>;
+
+        }
         return (
             <>
-                <div className="login">
-                    <div className="clay-site-container container-fluid">
-                        <div className="row">
-                            <div className="col-md-12">
-                                <div className="sheet">
-                                    <div className="sheet-header">
-                                        <h2 className="sheet-title">Login</h2>
-                                    </div>
-                                    <form method="post" onSubmit={event => {
-                                        this._handleSubmit(event);
-                                    }}>
-                                        <div className="form-group">
-                                            <label htmlFor="basicInputTypeEmail">Email</label>
-                                            <input className="form-control" autoComplete="email" type="email" name="email" onChange={this.handleUpdate} id="basicInputTypeEmail" />
-                                        </div>
-                                        <div className="form-group">
-                                            <label htmlFor="basicInputTypePassword">Password</label>
-                                            <input className="form-control" autoComplete="current-password" id="basicInputTypePassword" onChange={this.handleUpdate} placeholder="Enter password" name="password" type="password" />
-                                        </div>
-                                        <div className="form-group">
-                                            <div className="btn-group">
-                                                <div className="btn-group-item">
-                                                    <button className="btn btn-primary" type="submit">Submit</button>
-                                                </div>
-                                                <div className="btn-group-item">
-                                                    <a className="btn btn-secondary" onClick={(event) => {
-                                                        this._handleSignUp(event);
-                                                    }} href="#no">Sign Up</a>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                {button}
             </>
         )
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8460,6 +8460,11 @@ neo-async@^2.5.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
   integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
 
+netlify-identity-widget@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/netlify-identity-widget/-/netlify-identity-widget-1.5.2.tgz#c3bc18e275ebb4e8030bba31dfc38c9f2a540346"
+  integrity sha512-A1Pwnk+Bun+Xb0hO8w9g8plrhJah3jNomqWLFnd6GvGQ4jfhUS5jCzh/Cn6uHhuGNnriSUV0lFCKb3VJBsiZeQ==
+
 next-tick@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"


### PR DESCRIPTION
Since [WeDeploy is discontinued](https://wedeploy.com/blog/discontinuing-wedeploy/), I updated the authentication process — as a proposal — to use [Netlify Identity](https://www.netlify.com/docs/identity/).

It can be tested **[here](https://distracted-shannon-75f9c6.netlify.com)**. In this example, I made _Docs_ private. Known minor issue: when redirected after login with external provider (e.g. GitHub) or from email confirmation, the login/logout button doesn't update automatically (either you click on it, or you go to private area).

A new environment variable is available: _NETLIFY_IDENTITY_API_URL_. For its usage, here's [what Netlify recommends](https://github.com/netlify/netlify-identity-widget/#netlifyidentityinitopts):

> Generally avoid setting the APIUrl. You should only set this when your app is served from a domain that differs from where the identity endpoint is served. This is common for Cordova or Electron apps where you host from localhost or a file.